### PR TITLE
fix(android): thread looper issue if JSI modules enabled

### DIFF
--- a/packages/react-native-external-display/android/src/main/java/com/externaldisplay/RNExternalDisplayManager.java
+++ b/packages/react-native-external-display/android/src/main/java/com/externaldisplay/RNExternalDisplayManager.java
@@ -29,7 +29,6 @@ public class RNExternalDisplayManager extends ViewGroupManager<RNExternalDisplay
   public RNExternalDisplayManager(ReactApplicationContext reactContext) {
     super();
     this.reactContext = reactContext;
-    this.helper = new ExternalDisplayHelper(reactContext, this);
   }
 
   @Override
@@ -39,6 +38,9 @@ public class RNExternalDisplayManager extends ViewGroupManager<RNExternalDisplay
 
   @Override
   public RNExternalDisplayView createViewInstance(ThemedReactContext context) {
+    if (this.helper == null) {
+      this.helper = new ExternalDisplayHelper(reactContext, this);
+    }
     RNExternalDisplayView view = new RNExternalDisplayView(context, this.helper);
     views.put(view, view);
     return view;


### PR DESCRIPTION
Looks like the thread behavior will be changed on initialization if JSI module enabled (Like [react-native-reanimated v2](https://github.com/software-mansion/react-native-reanimated)).