### PR TITLE
remove build tools version

### DIFF
--- a/packages/react-native-external-display/android/build.gradle
+++ b/packages/react-native-external-display/android/build.gradle
@@ -6,7 +6,6 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
-    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.
