### PR TITLE
Properly remove components

### DIFF
--- a/packages/react-native-external-display/android/src/main/java/com/externaldisplay/RNExternalDisplayView.java
+++ b/packages/react-native-external-display/android/src/main/java/com/externaldisplay/RNExternalDisplayView.java
@@ -59,13 +59,14 @@ public class RNExternalDisplayView extends ReactRootView implements LifecycleEve
 
   @Override
   public void removeViewAt(int index) {
-    if (index > 0) return;
     View child = getChildAt(index);
     super.removeView(child);
     subviews.remove(index);
-    if (wrap != null && wrap.getChildCount() > 0) {
+    if (wrap != null) {
       for (int i = 0; i < wrap.getChildCount(); i++) {
-        wrap.removeViewAt(i);
+        if (i == index) {
+          wrap.removeViewAt(i);
+        }
       }
     }
   }


### PR DESCRIPTION
I'm experiencing a problem with rendering artifacts when changing content on the external screen, as described at https://github.com/mybigday/react-native-external-display/issues/368. This PR attempts to improve `RNExternalDisplayViewremoveViewAt`. So far, I haven't seen any `IndexOutOfBounds` error.